### PR TITLE
Add .do/app.yaml with server + migrate + static + db

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,0 +1,55 @@
+name: sample-django
+services:
+- name: server
+  github:
+    repo: digitalocean/sample-django
+    branch: static
+    deploy_on_push: true
+  run_command: python manage.py runserver 0.0.0.0:${PORT:-8080}
+  envs:
+  - key: DISABLE_COLLECTSTATIC
+    value: "1"
+    scope: BUILD_TIME
+  - key: DATABASE_URL
+    value: "${db.DATABASE_URL}"
+    scope: RUN_TIME
+  - key: DJANGO_ALLOWED_HOSTS
+    value: "${APP_DOMAIN}"
+    scope: RUN_TIME
+jobs:
+- name: migrate
+  kind: PRE_DEPLOY
+  github:
+    repo: digitalocean/sample-django
+    branch: static
+    deploy_on_push: true
+  run_command: python manage.py migrate
+  envs:
+  - key: DISABLE_COLLECTSTATIC
+    value: "1"
+    scope: BUILD_TIME
+  - key: DATABASE_URL
+    value: "${db.DATABASE_URL}"
+    scope: RUN_TIME
+static_sites:
+- name: static
+  github:
+    repo: digitalocean/sample-django
+    branch: static
+    deploy_on_push: true
+  # This happens as part of the Python/DJango buildpack:
+  # build_command: python manage.py collectstatic --noinput
+  output_dir: staticfiles
+  routes:
+  - path: /static
+databases:
+# Create a new dev DB:
+- name: db
+  engine: PG
+  version: "12"
+# Or bring an existing DB:
+# - name: db
+#   production: true
+#   cluster_name: mydb
+#   engine: PG
+#   version: "12"

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -5,7 +5,7 @@ services:
     repo: digitalocean/sample-django
     branch: static
     deploy_on_push: true
-  run_command: python manage.py runserver 0.0.0.0:${PORT:-8080}
+  run_command: gunicorn --worker-tmp-dir /dev/shm mysite.wsgi
   envs:
   - key: DISABLE_COLLECTSTATIC
     value: "1"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 db.sqlite3
 *.pyc
+staticfiles/

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 from pathlib import Path
 import os
+import sys
 from urllib.parse import urlparse
 
 from django.core.management.utils import get_random_secret_key
@@ -85,7 +86,7 @@ if os.getenv("DEVELOPMENT_MODE", "False") == "True":
             "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
         }
     }
-else:
+elif len(sys.argv) > 0 and sys.argv[1] != 'collectstatic':
     if os.getenv("DATABASE_URL", None) is None:
         raise Exception("DATABASE_URL environment variable not defined")
     r = urlparse(os.environ.get("DATABASE_URL"))

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 from pathlib import Path
 import os
 import sys
+import dj_database_url
 from urllib.parse import urlparse
 
 from django.core.management.utils import get_random_secret_key
@@ -89,17 +90,8 @@ if os.getenv("DEVELOPMENT_MODE", "False") == "True":
 elif len(sys.argv) > 0 and sys.argv[1] != 'collectstatic':
     if os.getenv("DATABASE_URL", None) is None:
         raise Exception("DATABASE_URL environment variable not defined")
-    r = urlparse(os.environ.get("DATABASE_URL"))
     DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.postgresql_psycopg2",
-            "NAME": os.path.relpath(r.path, "/"),
-            "USER": r.username,
-            "PASSWORD": r.password,
-            "HOST": r.hostname,
-            "PORT": r.port,
-            "OPTIONS": {"sslmode": "require"},
-        }
+        "default": dj_database_url.parse(os.environ.get("DATABASE_URL")),
     }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ psycopg2-binary==2.8.6
 pytz==2020.1
 sqlparse==0.3.1
 whitenoise==5.2.0
+dj-database-url==0.5.0


### PR DESCRIPTION
I was playing around with this to help with answering a community question. It adds a `.do/app.yaml` with components for the server service, migration job, staticfiles static site, and dev db. It also updates `settings.py` to not try the DB connection for `collectstatic` and use `dj-database-url` for the `DATABASE_URL` env.

```
doctl apps create --spec .do/app.yaml
```

https://sample-django-xi5fd.ondigitalocean.app/